### PR TITLE
Migrate Docker image to GHCR.io

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -7,7 +7,7 @@ name: Docker
 
 on:
   schedule:
-    - cron: '0 9 1 * *'
+    - cron: '0 7 * * *'
   push:
     branches: [ master ]
     # Publish semver tags as releases.

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -7,7 +7,7 @@ name: Docker
 
 on:
   schedule:
-    - cron: '28 0 * * *'
+    - cron: '0 9 1 * *'
   push:
     branches: [ master ]
     # Publish semver tags as releases.

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,63 @@
+name: Docker
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+on:
+  schedule:
+    - cron: '28 0 * * *'
+  push:
+    branches: [ master ]
+    # Publish semver tags as releases.
+    tags: [ 'v*.*.*' ]
+  pull_request:
+    branches: [ master ]
+
+env:
+  # Use docker.io for Docker Hub if empty
+  REGISTRY: ghcr.io
+  # github.repository as <account>/<repo>
+  IMAGE_NAME: ${{ github.repository }}
+
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      # Login against a Docker registry except on PR
+      # https://github.com/docker/login-action
+      - name: Log into registry ${{ env.REGISTRY }}
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@28218f9b04b4f3f62068d7b6ce6ca5b26e35336c
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Extract metadata (tags, labels) for Docker
+      # https://github.com/docker/metadata-action
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      # Build and push Docker image with Buildx (don't push on PR)
+      # https://github.com/docker/build-push-action
+      - name: Build and push Docker image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN    mkdir /home/gap/inst/gap-${GAP_BRANCH}/pkg \
     && cd /home/gap/inst/gap-${GAP_BRANCH}/pkg \
     && curl https://files.gap-system.org/gap4pkgs/packages-${GAP_BRANCH}.tar.gz | tar xz \
     && cd ZeroMQ* \
-    && wget -O - https://github.com/gap-packages/ZeroMQInterface/pull/26.patch | patch -p1 \
+    && wget -O - https://github.com/gap-packages/ZeroMQInterface/pull/26.patch | patch -p1 -N \
     && cd .. \
     && ../bin/BuildPackages.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN    mkdir /home/gap/inst/gap-${GAP_BRANCH}/pkg \
 RUN    cd /home/gap/inst/gap-${GAP_BRANCH}/pkg \
     && mv JupyterKernel-* JupyterKernel \
     && cd JupyterKernel \
-    && python3 setup.py install --user
+    && pip3 install . --user
 
 RUN jupyter serverextension enable --py jupyterlab --user
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,9 +24,6 @@ RUN    mkdir /home/gap/inst/ \
 RUN    mkdir /home/gap/inst/gap-${GAP_BRANCH}/pkg \
     && cd /home/gap/inst/gap-${GAP_BRANCH}/pkg \
     && curl https://files.gap-system.org/gap4pkgs/packages-${GAP_BRANCH}.tar.gz | tar xz \
-    && cd ZeroMQ* \
-    && wget -O - https://github.com/gap-packages/ZeroMQInterface/pull/26.patch | patch -p1 -N \
-    && cd .. \
     && ../bin/BuildPackages.sh
 
 # build JupyterKernel


### PR DESCRIPTION
Addition of Github workflow to move the docker image to instead be hosted on Github's internal container repository.