### PR TITLE
Remove piping from packages download

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,8 @@ RUN    mkdir /home/gap/inst/ \
 # download and build GAP packages
 RUN    mkdir /home/gap/inst/gap-${GAP_BRANCH}/pkg \
     && cd /home/gap/inst/gap-${GAP_BRANCH}/pkg \
-    && curl https://files.gap-system.org/gap4pkgs/packages-${GAP_BRANCH}.tar.gz | tar xz \
+    && wget -q https://files.gap-system.org/gap4pkgs/packages-${GAP_BRANCH}.tar.gz \
+    && tar xzf packages-${GAP_BRANCH}.tar.gz \
     && ../bin/BuildPackages.sh
 
 # build JupyterKernel


### PR DESCRIPTION
Caused issues with incomplete downloads when deploying the image to GHCR.io